### PR TITLE
Added note about disabling App Engine.

### DIFF
--- a/session-02/hands-on-05/README.md
+++ b/session-02/hands-on-05/README.md
@@ -194,6 +194,8 @@ $ gcloud app browse
 
 1. Follow the instructions above and deploy the code you've been working on so
    far to App Engine. Verify that it works.
+   
+Note: Don't forget to stop the App Engine when you're done. This can be done in the [App Engine settings](https://console.cloud.google.com/appengine/settings).
 
 # Congratulations!
 


### PR DESCRIPTION
I suppose you might be able to do this with the `gcloud deployment-manager` as well?
Either way, had to spend at least a couple of minutes to find out where to disable it again after deployment, but I may just be a terrible fit for the Google Cloud Platform Dashboard. Freely ignore if this is superfluous information.